### PR TITLE
Adjust composer package name

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "statamic/statamic",
+    "name": "jonassiewertsen/statamic-butik-starter-kit",
     "description": "Statamic",
     "keywords": ["statamic", "cms", "flat file", "laravel"],
     "type": "project",


### PR DESCRIPTION
This allows the starter kit to be installed through the statamic/cli tool.

See https://github.com/statamic/cli/pull/25#issuecomment-736678333